### PR TITLE
run nopaste asynchronously

### DIFF
--- a/nopaste.el
+++ b/nopaste.el
@@ -80,6 +80,13 @@ Will use `nopaste' in your system's $PATH by default")
   name. For example, can be set to `*nopaste*' to see the output
   of the command interactively.")
 
+(defvar nopaste-proc-buffer-errors "*nopaste-errors*"
+  "Buffer name where to send errors from the subprocess. Can be
+  set to `nil' to use the same buffer as `nopaste-proc-buffer`,
+  but that also has the side-effect of sending errors to the
+  `nopaste-handler' which might be confusing because errors will
+  be mixed with URLs.")
+
 (defcustom nopaste-type-assoc
   '((actionscript-mode . " actionscript")
     (ada-mode . "ada")
@@ -211,6 +218,7 @@ and `END' aren't optional, i.e it also takes `NICKNAME'
                               :command (cons "nopaste" args)
                               :connection-type 'pipe
                               :buffer nopaste-proc-buffer
+                              :stderr nopaste-proc-buffer-errors
                               :name "nopaste")))
       (process-send-region proc start end)
       (process-send-eof proc)

--- a/nopaste.el
+++ b/nopaste.el
@@ -244,6 +244,11 @@ and `END' aren't optional, i.e it also takes `NICKNAME'
   (when nopaste-proc-buffer
     (nopaste-ordinary-insertion-filter proc string))
   (setq status (process-exit-status proc))
+  (setq err-format "Error: %s failed with exit value %d")
+  (when nopaste-proc-buffer-errors
+    (setq err-format (concat err-format
+                             (format ", see %s for details"
+                                     nopaste-proc-buffer-errors))))
   (if (= status 0)
       ;; TODO: the chomp might want to check for errors if the
       ;; sentinel doesn't suffice
@@ -253,8 +258,7 @@ and `END' aren't optional, i.e it also takes `NICKNAME'
           (kill-new url))
         (setq nopaste-last-url url))
     ;; TODO: this should be handled in a sentinel instead
-    (error "Error: %s failed with exit value %d: %s"
-           (process-command proc) status string)))
+    (error err-format (process-command proc) status)))
   
 (defun nopaste-yank-url ()
   "Insert the URL of the last nopaste at point."


### PR DESCRIPTION
This keeps Emacs interactive while the paste is in progress. URL information is shown through a filter handler instead of synchronously, which means Emacs won't hang when sending content to the paste server. This matters because some pastebin can get busy or slow, especially on slower connexions, which currently makes Emacs completely unresponsive when pasting.

By default, the standard output of the command is discard but the "chomped" URL is shown to the user and copied to the kill ring, as before. Standard error is kept in a `*nopaste-errors*` buffer for perusal on errors, and a `sentinel` function handles such errors and defer the user to that buffer in case of problems. That was tested by disabling the network on my workstation and seems to behave well enough.

The last commit also includes some style changes to the code to comply with common conventions.